### PR TITLE
Fix Firefox scroll-event problem on home page

### DIFF
--- a/src/containers/HomePage/SectionContainer.js
+++ b/src/containers/HomePage/SectionContainer.js
@@ -16,6 +16,7 @@ class SectionContainer extends Component {
     };
   }
   componentDidMount() {
+    window.addEventListener('DOMMouseScroll', this.handleWheel);
     window.addEventListener('mousewheel', this.handleWheel);
     window.addEventListener('keydown', this.handleKeydown);
     const hammer = new Hammer(document);
@@ -23,6 +24,7 @@ class SectionContainer extends Component {
     hammer.on('swipe', this.handleSwipe);
   }
   componentWillUnmount() {
+    window.removeEventListener('DOMMouseScroll', this.handleWheel);
     window.removeEventListener('mousewheel', this.handleWheel);
     window.removeEventListener('keydown', this.handleKeydown);
     clearTimeout(this.timer);


### PR DESCRIPTION
在 Firefox 上 `mousewheel` 無效，只看得懂 `DOMMouseScroll`...
造成 Firefox 上無法使用 scroll 滾動首頁的 sections

我的修正方法是加一行 `DOMMouseScroll` event handler 😂 

Ref: [mousewheel on MDN](https://developer.mozilla.org/en-US/docs/Web/Events/mousewheel)
